### PR TITLE
Fix rating state initialization for SSR

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,11 @@ export default function Home() {
   const [moveIndex, setMoveIndex] = useState(0);
   const [status, setStatus] = useState("");
   const [rating, setRating] = useState<number>(() => {
-    const saved = localStorage.getItem("rating_" + user);
-    return saved ? parseInt(saved) : 1000;
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("rating_" + user);
+      return saved ? parseInt(saved) : 1000;
+    }
+    return 1000;
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid server-side `localStorage` access by guarding with `typeof window !== "undefined"`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684467f674a083319fac323b48ddb31e