### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 out/
 dist/
 build/
-package-lock.json
 yarn.lock
 pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- stop ignoring `package-lock.json` so that the existing lockfile stays tracked

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68446ad907d48331bbd1e79ce0d4b8ae