### PR TITLE
Исправить деплой на Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "export"
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Изменения
- удалён параметр `output: 'export'` из `next.config.js`, что мешал стандартной сборке Next.js и приводил к ошибке на Vercel

## Тестирование
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68448a63c94c8331b2e12be1b417b623