### PR TITLE
Add click move controls with hints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chess-puzzle-app",
       "version": "1.0.0",
       "dependencies": {
+        "chess.js": "^1.0.0-beta.2",
         "chessboardjsx": "^2.4.7",
         "next": "13.4.19",
         "react": "18.2.0",
@@ -253,6 +254,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chess.js": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.0.0-beta.2.tgz",
+      "integrity": "sha512-B8G0PpTTUWvc5vRZDHmV9U+2i5+N583o+irxZwVNIVleXUBrkZC1TEdp6kMsnEs/QmhOHbKrmAr+8nz7zZOs6g==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/chessboardjsx": {
       "version": "2.4.7",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "chess.js": "^1.0.0-beta.2",
     "chessboardjsx": "^2.4.7",
     "next": "13.4.19",
     "react": "18.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import puzzles from "@/data/puzzles.json";
 import { Leaderboard } from "@/components/Leaderboard";
+import { Chess } from "chess.js";
 
 const Chessboard = dynamic(() => import("chessboardjsx"), { ssr: false });
 
@@ -14,6 +15,11 @@ export default function Home() {
   const [solution, setSolution] = useState<string[]>([]);
   const [moveIndex, setMoveIndex] = useState(0);
   const [status, setStatus] = useState("");
+  const [game, setGame] = useState<Chess | null>(null);
+  const [selectedSquare, setSelectedSquare] = useState<string | null>(null);
+  const [legalSquares, setLegalSquares] = useState<string[]>([]);
+  const [squareStyles, setSquareStyles] = useState<Record<string, any>>({});
+  const [showLeaderboard, setShowLeaderboard] = useState(false);
   const [rating, setRating] = useState<number>(() => {
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem("rating_" + user);
@@ -28,11 +34,16 @@ export default function Home() {
     setSolution(puzzle.solution);
     setStatus("");
     setMoveIndex(0);
+    const g = new Chess(puzzle.fen);
+    setGame(g);
   }, []);
 
-  const onDrop = ({ sourceSquare, targetSquare }: any) => {
-    const move = sourceSquare + targetSquare;
+  const applyMove = (from: string, to: string) => {
+    if (!game) return;
+    const move = from + to;
     if (move === solution[moveIndex]) {
+      (game as any).move({ from, to });
+      setFen(game.fen());
       if (moveIndex + 1 === solution.length) {
         setStatus("✅ Правильно!");
         const newRating = rating + 10;
@@ -49,13 +60,63 @@ export default function Home() {
     }
   };
 
+  const onSquareClick = (square: string) => {
+    if (!game) return;
+
+    if (selectedSquare) {
+      if (legalSquares.includes(square)) {
+        applyMove(selectedSquare, square);
+      }
+      setSelectedSquare(null);
+      setLegalSquares([]);
+      setSquareStyles({});
+    } else {
+      const piece = (game as any).get(square);
+      if (piece && piece.color === game!.turn()) {
+        const moves = (game as any).moves({ square, verbose: true }).map((m: any) => m.to);
+        setSelectedSquare(square);
+        setLegalSquares(moves);
+        const highlight: Record<string, any> = {};
+        highlight[square] = { backgroundColor: "rgba(0,255,0,0.4)" };
+        moves.forEach((sq) => {
+          highlight[sq] = { backgroundColor: "rgba(255,255,0,0.4)" };
+        });
+        setSquareStyles(highlight);
+      }
+    }
+  };
+
+  const showHint = () => {
+    setStatus(`Правильный ход: ${solution[moveIndex]}`);
+    const newRating = Math.max(0, rating - 10);
+    setRating(newRating);
+    localStorage.setItem("rating_" + user, newRating.toString());
+  };
+
   return (
     <main className="p-4">
       <h2 className="text-xl mb-2">Реши шахматную задачу</h2>
-      <Chessboard position={fen} onDrop={onDrop} width={350} />
+      <Chessboard
+        position={fen}
+        width={350}
+        onSquareClick={onSquareClick}
+        squareStyles={squareStyles}
+        draggable={false}
+      />
+      <div className="mt-2">
+        <button className="mr-2 px-2 py-1 bg-gray-200" onClick={showHint}>
+          Подсказка
+        </button>
+        <button
+          className="px-2 py-1 bg-gray-200"
+          onClick={() => setShowLeaderboard(!showLeaderboard)}
+        >
+          Лидеры
+        </button>
+      </div>
       <p className="mt-2">{status}</p>
       <p className="mt-2">Рейтинг: {rating}</p>
-      <Leaderboard />
+      {showLeaderboard && <Leaderboard />}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- switch puzzle board to click-based movement and disable drag
- highlight available moves on click
- add hint button that reduces rating
- show leaderboard via toggle button
- add chess.js dependency for move generation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844907dc35483319321f787e0b17450