### PR TITLE
Enhance mobile board layout

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -176,32 +176,44 @@ export default function Home() {
     setSquareStyles(highlight);
   };
 
+  useEffect(() => {
+    if (!status) return;
+    const t = setTimeout(() => setStatus(""), 1000);
+    return () => clearTimeout(t);
+  }, [status]);
+
+  const boardWidth = 320;
+
   return (
     <main className="p-4">
       <h2 className="text-xl mb-2">Реши шахматную задачу</h2>
-      <Chessboard
-        position={fen}
-        width={350}
-        onSquareClick={onSquareClick}
-        squareStyles={squareStyles}
-        orientation={orientation}
-        boardStyle={{ border: "2px solid #444" }}
-        lightSquareStyle={{ backgroundColor: "#f0d9b5" }}
-        darkSquareStyle={{ backgroundColor: "#b58863" }}
-        draggable={false}
-      />
-      <div className="mt-2">
-        <button className="mr-2 px-2 py-1 bg-gray-200" onClick={showHint}>
+      <div style={{ position: "relative", width: boardWidth, margin: "0 auto" }}>
+        <Chessboard
+          position={fen}
+          width={boardWidth}
+          onSquareClick={onSquareClick}
+          squareStyles={squareStyles}
+          orientation={orientation}
+          boardStyle={{ border: "2px solid #444" }}
+          lightSquareStyle={{ backgroundColor: "#f0d9b5" }}
+          darkSquareStyle={{ backgroundColor: "#b58863" }}
+          draggable={false}
+        />
+        {status && (
+          <div className={`status-overlay show`}>{status}</div>
+        )}
+      </div>
+      <div className="buttons">
+        <button className="btn" onClick={showHint}>
           Подсказка
         </button>
         <button
-          className="px-2 py-1 bg-gray-200"
+          className="btn"
           onClick={() => setShowLeaderboard(!showLeaderboard)}
         >
           Лидеры
         </button>
       </div>
-      <p className="mt-2">{status}</p>
       <p className="mt-2">Рейтинг: {rating}</p>
       {showLeaderboard && <Leaderboard />}
     </main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,3 +7,38 @@ body {
 .leaderboard {
   color: #000;
 }
+
+.buttons {
+  display: flex;
+  margin-top: 8px;
+}
+
+.btn {
+  flex: 1;
+  padding: 8px;
+  font-size: 16px;
+  margin: 0 4px;
+  background-color: #e0e0e0;
+  border: 1px solid #888;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.status-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background-color: rgba(255, 255, 255, 0.8);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.status-overlay.show {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- center the board and make it slightly smaller
- enlarge hint and leaders buttons and update styling
- overlay puzzle result across the board with fade animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844cad2ea808331be16fb87227846d6