### PR TITLE
Implement Stockfish-based puzzles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "chess.js": "^1.0.0-beta.2",
         "chessboardjsx": "^2.4.7",
-        "js-chess-engine": "^1.0.2",
         "next": "13.4.19",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -348,12 +347,6 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "node_modules/js-chess-engine": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-chess-engine/-/js-chess-engine-1.0.2.tgz",
-      "integrity": "sha512-oOFuP3/+Ef7SAWcL+8tDAQNcPFuyul6XI/2NypRblqchI4UbYkWNNxVi//XEQW8L242Jk21ljLhllSyRGEFlGg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "chess.js": "^1.0.0-beta.2",
     "chessboardjsx": "^2.4.7",
-    "js-chess-engine": "^1.0.2",
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/pages/api/puzzle.ts
+++ b/pages/api/puzzle.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Chess } from 'chess.js';
-import { Game } from 'js-chess-engine';
+import { spawn } from 'child_process';
 
 function randomFen(): string {
   const chess = new Chess();
@@ -14,28 +14,47 @@ function randomFen(): string {
   return chess.fen();
 }
 
-function aiLine(fen: string): string[] | null {
-  const game = new Game(fen);
-  const solution: string[] = [];
-  for (let i = 0; i < 6; i++) {
-    const m = game.aiMove(3); // reduced depth for speed
-    const from = Object.keys(m)[0];
-    const to = m[from];
-    solution.push(from + to);
-    const status = game.exportJson();
-    if (status.checkMate) return solution;
-  }
-  return null;
+async function stockfishLine(fen: string): Promise<string[] | null> {
+  return new Promise((resolve) => {
+    const engine = spawn('/usr/games/stockfish');
+    let pv: string[] = [];
+    let found = false;
+    engine.stdout.on('data', (data) => {
+      const lines = data.toString().split('\n');
+      for (const line of lines) {
+        if (line.startsWith('info')) {
+          const m = line.match(/score mate (-?\d+)/);
+          if (m) {
+            const ply = Math.abs(parseInt(m[1], 10));
+            if (ply <= 6) {
+              found = true;
+              const pvMatch = line.match(/ pv (.+)/);
+              if (pvMatch) {
+                pv = pvMatch[1].trim().split(' ');
+              }
+            }
+          }
+        } else if (line.startsWith('bestmove')) {
+          engine.kill();
+          resolve(found ? pv.slice(0, 6) : null);
+        }
+      }
+    });
+    engine.stdin.write('uci\n');
+    engine.stdin.write('isready\n');
+    engine.stdin.write('position fen ' + fen + '\n');
+    engine.stdin.write('go depth 6\n');
+  });
 }
 
-export default function handler(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   try {
     for (let i = 0; i < 20; i++) {
       const fen = randomFen();
-      const solution = aiLine(fen);
+      const solution = await stockfishLine(fen);
       if (solution && solution.length >= 2) {
         res.status(200).json({ fen, solution });
         return;


### PR DESCRIPTION
## Summary
- generate chess puzzles using Stockfish instead of js-chess-engine
- remove unused chess engine packages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d9d2f04c8331b9de101cfbda298c