### PR TITLE
Add move highlights and revamped difficulty selector

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,3 +42,8 @@ body {
 .status-overlay.show {
   opacity: 1;
 }
+
+.slider {
+  width: 100%;
+  accent-color: #6b46c1;
+}


### PR DESCRIPTION
## Summary
- highlight available moves and last move on board
- replace difficulty dropdown with a slider for a nicer look

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684566132b388331961dfed54bd75043