### PR TITLE
Add move highlighting and pause menu

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ export default function Home() {
   const [squareStyles, setSquareStyles] = useState<Record<string, any>>({});
   const [lastMove, setLastMove] = useState<string[]>([]);
   const [message, setMessage] = useState("");
+  const [paused, setPaused] = useState(false);
 
   const highlightSquares = (
     from: string | null,
@@ -28,13 +29,13 @@ export default function Home() {
     const styles: Record<string, any> = {};
     if (lm.length === 2) {
       const [f, t] = lm;
-      styles[f] = { backgroundColor: "rgba(255,215,0,0.5)" };
-      styles[t] = { backgroundColor: "rgba(255,215,0,0.5)" };
+      styles[f.toLowerCase()] = { backgroundColor: "rgba(255,215,0,0.5)" };
+      styles[t.toLowerCase()] = { backgroundColor: "rgba(255,215,0,0.5)" };
     }
     if (from) {
-      styles[from] = { boxShadow: "inset 0 0 0 3px rgba(50,150,255,0.8)" };
+      styles[from.toLowerCase()] = { boxShadow: "inset 0 0 0 3px rgba(50,150,255,0.8)" };
       moves.forEach((sq) => {
-        styles[sq] = {
+        styles[sq.toLowerCase()] = {
           background:
             "radial-gradient(circle, rgba(50,150,255,0.7) 20%, rgba(0,0,0,0) 22%)",
         };
@@ -47,6 +48,7 @@ export default function Home() {
     const g = new Game();
     setGame(g);
     setMenu(false);
+    setPaused(false);
     const f = g.exportFEN();
     setFen(f);
     if (color === "black") {
@@ -59,7 +61,7 @@ export default function Home() {
   };
 
   const onSquareClick = (square: string) => {
-    if (!game) return;
+    if (!game || paused) return;
     square = square.toUpperCase();
     if (selected) {
       if (legal.includes(square)) {
@@ -87,7 +89,7 @@ export default function Home() {
   };
 
   const onMouseOverSquare = (square: string) => {
-    if (!game || selected) return;
+    if (!game || selected || paused) return;
     square = square.toUpperCase();
     const state = game.exportJson();
     if (
@@ -99,7 +101,7 @@ export default function Home() {
   };
 
   const onMouseOutSquare = () => {
-    if (!selected) {
+    if (!selected && !paused) {
       highlightSquares(null, []);
     }
   };
@@ -123,11 +125,23 @@ export default function Home() {
     }
   };
 
+  const returnToMenu = () => {
+    setMenu(true);
+    setGame(null);
+    setMessage("");
+    setSelected(null);
+    setLegal([]);
+    setPaused(false);
+    setFen("");
+    setSquareStyles({});
+    setLastMove([]);
+  };
+
   const boardWidth = 320;
 
   if (menu) {
     return (
-      <main className="p-4">
+      <main className="p-4 menu-screen">
         <h2 className="text-xl mb-2">Шахматы с компьютером</h2>
         <div className="mb-4">
           <label className="block mb-1">Цвет фигур</label>
@@ -160,7 +174,7 @@ export default function Home() {
             <button onClick={() => setLevel(Math.min(69, level + 1))}>+</button>
           </div>
         </div>
-        <button className="btn" onClick={startGame}>
+        <button className="btn full-width" onClick={startGame}>
           Начать игру
         </button>
       </main>
@@ -170,6 +184,9 @@ export default function Home() {
   return (
     <main className="p-4">
       <h2 className="text-xl mb-2">Игра</h2>
+      <button className="btn full-width mb-2" onClick={() => setPaused(true)}>
+        Пауза
+      </button>
       <div
         style={{ position: "relative", width: boardWidth, margin: "0 auto" }}
       >
@@ -187,6 +204,16 @@ export default function Home() {
           draggable={false}
         />
         {message && <div className="status-overlay show">{message}</div>}
+        {paused && (
+          <div className="pause-overlay">
+            <button className="btn" onClick={() => setPaused(false)}>
+              Продолжить
+            </button>
+            <button className="btn" onClick={returnToMenu}>
+              В меню
+            </button>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,5 @@
 body {
-  background-color: #f2f2f2;
+  background-color: #f5f5fa;
   color: #333;
   font-family: Arial, sans-serif;
 }
@@ -18,10 +18,20 @@ body {
   padding: 8px;
   font-size: 16px;
   margin: 0 4px;
-  background-color: #e0e0e0;
-  border: 1px solid #888;
+  background-color: #6b46c1;
+  color: #fff;
+  border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.btn.full-width {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.mb-2 {
+  margin-bottom: 8px;
 }
 
 .status-overlay {
@@ -93,4 +103,29 @@ body {
   padding: 4px;
   border: 1px solid #888;
   border-radius: 4px;
+}
+
+.menu-screen {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.pause-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.pause-overlay .btn {
+  width: 80%;
+  margin: 4px 0;
 }


### PR DESCRIPTION
## Summary
- highlight legal moves for selected pieces
- adjust menu layout and button styles
- add pause menu with continue and exit options

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68456d843d988331a1201e4fcaab8494