### PR TITLE
Improve chess UI

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -150,6 +150,28 @@ export default function Home() {
 
   const boardWidth = 320;
 
+  const restartGame = () => {
+    const g = new Game();
+    setGame(g);
+    setMessage("");
+    setSelected(null);
+    setLegal([]);
+    setPaused(false);
+    setSquareStyles({});
+    setLastMove([]);
+    setMoves([]);
+    const f = g.exportFEN();
+    setFen(f);
+    if (color === "black") {
+      const ai = g.aiMove(mapDifficulty(level)) as Record<string, string>;
+      const [from, to] = Object.entries(ai)[0];
+      setLastMove([from, to]);
+      setMoves((m) => [...m, `${from}-${to}`]);
+      setFen(g.exportFEN());
+      highlightSquares(null, [], [from, to]);
+    }
+  };
+
   if (menu) {
     return (
       <main className="p-4 menu-screen">
@@ -198,9 +220,7 @@ export default function Home() {
       <button className="btn pause full-width mb-2" onClick={() => setPaused(true)}>
         Пауза
       </button>
-      <div
-        style={{ position: "relative", width: boardWidth, margin: "0 auto" }}
-      >
+      <div className="board-container">
         <Chessboard
           position={fen}
           width={boardWidth}
@@ -209,9 +229,9 @@ export default function Home() {
           onMouseOutSquare={onMouseOutSquare}
           squareStyles={squareStyles}
           orientation={color}
-          boardStyle={{ border: "2px solid #444" }}
-          lightSquareStyle={{ backgroundColor: "#f0d9b5" }}
-          darkSquareStyle={{ backgroundColor: "#b58863" }}
+          boardStyle={{ border: "2px solid #222" }}
+          lightSquareStyle={{ backgroundColor: "#eeeed2" }}
+          darkSquareStyle={{ backgroundColor: "#769656" }}
           draggable={false}
         />
         {message && <div className="status-overlay show">{message}</div>}
@@ -220,8 +240,11 @@ export default function Home() {
             <button className="btn start" onClick={() => setPaused(false)}>
               Продолжить
             </button>
+            <button className="btn restart" onClick={restartGame}>
+              Новая игра
+            </button>
             <button className="btn" onClick={returnToMenu}>
-              В меню
+              Сдаться
             </button>
           </div>
         )}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,7 @@
 body {
-  background-color: #f5f5fa;
-  color: #333;
-  font-family: Arial, sans-serif;
+  background-color: #262421;
+  color: #eee;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 .leaderboard {
@@ -18,10 +18,10 @@ body {
   padding: 10px;
   font-size: 16px;
   margin: 0 4px;
-  background-color: #666;
+  background-color: #4a4a4a;
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
   transition: background-color 0.2s;
   display: inline-flex;
@@ -30,23 +30,31 @@ body {
 }
 
 .btn:hover {
-  background-color: #555;
+  background-color: #3c3c3c;
 }
 
 .btn.start {
-  background-color: #4caf50;
+  background-color: #388e3c;
 }
 
 .btn.start:hover {
-  background-color: #45a049;
+  background-color: #2e7d32;
 }
 
 .btn.pause {
-  background-color: #f44336;
+  background-color: #d32f2f;
 }
 
 .btn.pause:hover {
-  background-color: #d32f2f;
+  background-color: #b71c1c;
+}
+
+.btn.restart {
+  background-color: #1976d2;
+}
+
+.btn.restart:hover {
+  background-color: #115293;
 }
 
 .btn.full-width {
@@ -158,8 +166,18 @@ body {
   max-width: 320px;
   margin: 8px auto 0;
   padding: 4px;
-  background-color: #f5f5fa;
-  border: 1px solid #ccc;
+  background-color: #2b2b2b;
+  border: 1px solid #555;
   min-height: 40px;
   font-size: 14px;
+}
+
+.board-container {
+  position: relative;
+  width: 336px;
+  margin: 0 auto;
+  padding: 8px;
+  background-color: #312e2b;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
 }


### PR DESCRIPTION
## Summary
- modernize overall colors and fonts
- add restart feature during pause
- style board container and move log
- use green chessboard squares like chess.com

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68457345a3f88331b4cee82a52ccb89c